### PR TITLE
(global-pretty-mode t) generates a lot of garbage with swiper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ In your [`Cask` file](https://github.com/cask/cask):
 
 If you are using the emacs package `swiper` you might want to disable `global-pretty-mode` as it generates a lot of garbage and instead enable pretty mode on a per-mode basis with `turn-on-pretty-mode`
 
-
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ In your [`Cask` file](https://github.com/cask/cask):
 (add-hook 'my-pretty-language-hook 'turn-on-pretty-mode)
 ```
 
+If you are using the emacs package `swiper` you might want to disable `global-pretty-mode` as it generates a lot of garbage and instead enable pretty mode on a per-mode basis with `turn-on-pretty-mode`
+
+
 ## Development
 
 ```bash


### PR DESCRIPTION
(global-pretty-mode t) messes with swiper, making it generate a lot of garbage.
This is because (turn-on-pretty-if-desired) scans the whole document swiper works with (maybe multiple times).
I tested this by opening up pretty-mode.el with (global-pretty-mode t) and another time with (turn-on-pretty-mode). On both tests i did C-s (swiper) then C-g when swiper was done loading 10 times.
The results were that (global-pretty-mode t) generated 34 MB of garbage while (turn-on-pretty-mode) generated none.
I tried fixing this by creating a list with modes to ignore, but this turned out to make it even worse because it did the string comparison a lot of times per swiper search so I gave up. This update to the readme should atleast help inform everyone of the problem